### PR TITLE
app: make register() work when app first starts up

### DIFF
--- a/src/ndn/app.py
+++ b/src/ndn/app.py
@@ -366,6 +366,9 @@ class NDNApp:
         :raises ValueError: the prefix is already registered.
         :raises NetworkError: the face to NFD is down now.
         """
+        if not self.face.running:
+            self._autoreg_routes.append((name, func, validator, need_raw_packet, need_sig_ptrs))
+            return
         name = Name.normalize(name)
         node = self._prefix_tree.setdefault(name, PrefixTreeNode())
         if node.callback:


### PR DESCRIPTION
Currently, if `app.register()` is called before the tcp face is ready, it causes the error `NetworkError: cannot send packet before connected`.

In some cases, this forces users to abuse the use of `app.route()`, for example: 

https://github.com/JonnyKong/ndn-python-repo/blob/37ba6b9e754eff04581f8b8b8afa30b40255fb65/ndn_python_repo/handle/write_command_handle.py#L42-L48