### PR TITLE
encoding: Add to_canonical_uri to Name and Component

### DIFF
--- a/src/ndn/app_support/light_versec/checker.py
+++ b/src/ndn/app_support/light_versec/checker.py
@@ -308,6 +308,7 @@ class Checker:
                         if self.check(cert_name, cert.signature_info.key_locator.name):
                             return cert_name
 
+
 DEFAULT_USER_FNS = {
     '$eq': lambda c, args: all(x == c for x in args),
     '$eq_type': lambda c, args: all(Component.get_type(x) == Component.get_type(c) for x in args),

--- a/src/ndn/app_support/light_versec/compiler.py
+++ b/src/ndn/app_support/light_versec/compiler.py
@@ -22,8 +22,6 @@
 # -----------------------------------------------------------------------------
 from __future__ import annotations
 
-import typing
-
 import lark
 from typing import TypeVar, Union, Optional
 from dataclasses import dataclass

--- a/src/ndn/encoding/name/Component.py
+++ b/src/ndn/encoding/name/Component.py
@@ -322,6 +322,36 @@ def to_str(component: BinaryStr) -> str:
         return ret + "".join(decode(val) for val in component[offset:])
 
 
+def to_canonical_uri(component: BinaryStr) -> str:
+    """
+    Convert a Component into a canonical URI string without naming conventions.
+    Returns an empty string ``''`` for a 0-size Component.
+
+    :param component: the component.
+    :return: a canonical URI string.
+    """
+    offset = 0
+    typ, sz = parse_tl_num(component, offset)
+    offset += sz
+    length, sz = parse_tl_num(component, offset)
+    offset += sz
+    if len(component) != length + offset:
+        raise ValueError(f'{component} is malformed.')
+
+    ret = ""
+    if typ != TYPE_GENERIC:
+        ret = f"{typ}="
+
+    def decode(val: int) -> str:
+        ret = chr(val)
+        if ret in CHARSET and ret not in {'%', '='}:
+            return ret
+        else:
+            return f"%{val:02X}"
+
+    return ret + "".join(decode(val) for val in component[offset:])
+
+
 def to_number(component: BinaryStr) -> int:
     """
     Take the number encoded in the component out.

--- a/src/ndn/encoding/name/Name.py
+++ b/src/ndn/encoding/name/Name.py
@@ -87,6 +87,26 @@ def to_str(name: NonStrictName) -> str:
     return ret
 
 
+def to_canonical_uri(name: NonStrictName) -> str:
+    r"""
+    Convert an NDN Name to a canonical URI string without naming conventions.
+
+    :param name: the input NDN Name.
+    :type name: :any:`NonStrictName`
+    :return: the canonical URI.
+
+    :examples:
+        >>> from ndn.encoding.name import Name
+        >>> Name.to_canonical_uri('Σπυρίδων')
+        '/%CE%A3%CF%80%CF%85%CF%81%CE%AF%CE%B4%CF%89%CE%BD'
+    """
+    name = normalize(name)
+    ret = '/' + '/'.join(Component.to_canonical_uri(comp) for comp in name)
+    if name and name[-1] == b'\x08\x00':
+        ret += '/'
+    return ret
+
+
 def from_bytes(buf: BinaryStr) -> FormalName:
     r"""
     Decode the Name from its TLV encoded form.

--- a/tests/encoding/name_test.py
+++ b/tests/encoding/name_test.py
@@ -311,3 +311,8 @@ class TestName:
 
         name = ['8=a', 'b', b'\x08\x01c', '\x1d']
         assert Name.normalize(name) == [b'\x08\x01a', b'\x08\x01b', b'\x08\x01c', b'\x08\x01\x1d']
+
+    @staticmethod
+    def test_canonical_uri():
+        assert Name.to_canonical_uri(Name.from_str('/hello/world')) == '/hello/world'
+        assert Name.to_canonical_uri(Name.from_str('/8=hello/seg=1')) == '/hello/50=%01'

--- a/tests/integration/app_v2_test.py
+++ b/tests/integration/app_v2_test.py
@@ -57,7 +57,7 @@ class TestConsumerBasic(NDNAppTestSuite):
                                 b'\x15\rHello, world!')
 
     async def app_main(self):
-        name = f'/example/testApp/randomData/t=1570430517101'
+        name = '/example/testApp/randomData/t=1570430517101'
         data_name, content, pkt_context = await self.app.express(
             name, app.pass_all, must_be_fresh=True, can_be_prefix=False, lifetime=6000, nonce=None)
         assert data_name == enc.Name.from_str(name)
@@ -199,7 +199,7 @@ class TestConsumerRawPacket(NDNAppTestSuite):
                                 b'\x15\rHello, world!')
 
     async def app_main(self):
-        name = f'/example/testApp/randomData/t=1570430517101'
+        name = '/example/testApp/randomData/t=1570430517101'
         _, _, pkt_context = await self.app.express(
             name, validator=app.pass_all,
             must_be_fresh=True, can_be_prefix=False, lifetime=6000, nonce=None, need_raw_packet=True)

--- a/tests/misc/light_versec_test.py
+++ b/tests/misc/light_versec_test.py
@@ -16,10 +16,10 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
 import pytest
 from tempfile import TemporaryDirectory
-from ndn.encoding import Name, Component
+from ndn.encoding import Component
 from ndn.app_support.light_versec import compile_lvs, Checker, SemanticError, DEFAULT_USER_FNS
 from ndn.app_support.security_v2 import parse_certificate, derive_cert
 from ndn.security import KeychainSqlite3, TpmFile
@@ -301,9 +301,9 @@ class TestLvsSemantics:
         assert checker.check('/x/y/z', '/xxx/xxx/xxx')
         assert checker.check('/x/x/x', '/xxx/yyy/zzz')
         assert checker.check('/a/a/a', '/xxx/xxx/xxx')
-    
+
     @staticmethod
-    def test_signing_suggest():        
+    def test_signing_suggest():
         with TemporaryDirectory() as tmpdirname:
             pib_file = os.path.join(tmpdirname, 'pib.db')
             tpm_dir = os.path.join(tmpdirname, 'privKeys')
@@ -318,9 +318,9 @@ class TestLvsSemantics:
             la_signer = keychain.get_signer({'cert': la_cert_name})
 
             la_author_id = keychain.touch_identity('/la/author/1')
-            la_author_cert_name, la_author_cert = derive_cert(la_author_id.default_key().name, 
-                                                              Component.from_str('la-signer'), 
-                                                              la_cert_data.content, la_signer, 
+            la_author_cert_name, la_author_cert = derive_cert(la_author_id.default_key().name,
+                                                              Component.from_str('la-signer'),
+                                                              la_cert_data.content, la_signer,
                                                               datetime.utcnow(), 100)
             keychain.import_cert(la_id.default_key().name, la_author_cert_name, la_author_cert)
 
@@ -331,12 +331,11 @@ class TestLvsSemantics:
             ny_signer = keychain.get_signer({'cert': ny_cert_name})
 
             ny_author_id = keychain.touch_identity('/ny/author/2')
-            ny_author_cert_name, ny_author_cert = derive_cert(ny_author_id.default_key().name, 
+            ny_author_cert_name, ny_author_cert = derive_cert(ny_author_id.default_key().name,
                                                               Component.from_str('ny-signer'),
-                                                              ny_cert_data.content, ny_signer, 
+                                                              ny_cert_data.content, ny_signer,
                                                               datetime.utcnow(), 100)
             keychain.import_cert(ny_id.default_key().name, ny_author_cert_name, ny_author_cert)
-
 
             lvs = r'''
             #KEY: "KEY"/_/_/_
@@ -348,7 +347,7 @@ class TestLvsSemantics:
 
             assert checker.suggest("/article/eco/day1", keychain) == la_author_cert_name
             assert checker.suggest("/article/life/day1", keychain) is None
-            
+
             lvs = r'''
             #KEY: "KEY"/_/_/_
             #LAKEY: "KEY"/_/_signer/_ & { _signer: "la-signer" }
@@ -358,7 +357,7 @@ class TestLvsSemantics:
             '''
             checker = Checker(compile_lvs(lvs), {})
             assert checker.suggest("/article/eco/day1", keychain) == la_author_cert_name
-            
+
             lvs = r'''
             #KEY: "KEY"/_/_/_version & { _version: $eq_type("v=0") }
             #article: /"article"/_topic/_ & { _topic: "life" | "fin" } <= #author
@@ -367,7 +366,7 @@ class TestLvsSemantics:
             '''
             checker = Checker(compile_lvs(lvs), DEFAULT_USER_FNS)
             assert checker.suggest("/article/fin/day1", keychain) == ny_author_cert_name
-            
+
             lvs = r'''
             #KEY: "KEY"/_/_/_version & { _version: $eq_type("v=0") }
             #NYKEY: "KEY"/_/_signer/_version& { _signer: "ny-signer", _version: $eq_type("v=0")}
@@ -377,4 +376,4 @@ class TestLvsSemantics:
             #site: "ny"
             '''
             checker = Checker(compile_lvs(lvs), DEFAULT_USER_FNS)
-            assert checker.suggest("/article/eco/day1", keychain) == ny_author_cert_name        
+            assert checker.suggest("/article/eco/day1", keychain) == ny_author_cert_name


### PR DESCRIPTION
Mainly for the sake of NDN-DPDK's GraphQL command in 14th NDN Hackathon.